### PR TITLE
fix: resolve Home Assistant 2025.6 integration loading failure

### DIFF
--- a/custom_components/clage_homeserver/__init__.py
+++ b/custom_components/clage_homeserver/__init__.py
@@ -93,7 +93,7 @@ async def async_setup_entry(hass, config):
     # )
 
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config, ["sensor"])
+        hass.config_entries.async_forward_entry_setups(config, ["sensor"])
     )
     return True
 

--- a/custom_components/clage_homeserver/__init__.py
+++ b/custom_components/clage_homeserver/__init__.py
@@ -93,7 +93,7 @@ async def async_setup_entry(hass, config):
     # )
 
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config, "sensor")
+        hass.config_entries.async_forward_entry_setup(config, ["sensor"])
     )
     return True
 


### PR DESCRIPTION
- Replace async_forward_entry_setup with async_forward_entry_setups
- Update platform parameter to be passed as list
- Fixes ModuleNotFoundError on HA 2025.6+

Closes #19